### PR TITLE
ENH: Add OSSF scorecard action to quantify open-source health

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,59 @@
+name: Scorecard analysis workflow
+on:
+  # Only the default branch is supported.
+  branch_protection_rule:
+  schedule:
+    # Weekly on Saturdays.
+    - cron: '30 1 * * 6'
+  push:
+    branches: [ main ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed if using Code scanning alerts
+      security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@08b4669551908b1024bb425080c797723083c031 # v2.2.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # (Optional) fine-grained personal access token. Uncomment the `repo_token` line below if:
+          # - you want to enable the Branch-Protection check on a *public* repository, or
+          # To create the PAT, follow the steps in https://github.com/ossf/scorecard-action#authentication-with-fine-grained-pat-optional.
+          # repo_token: ${{ secrets.SCORECARD_TOKEN }}
+
+          # Publish the results for public repositories to enable scorecard badges. For more details, see
+          # https://github.com/ossf/scorecard-action#publishing-results.
+          # For private repositories, `publish_results` will automatically be set to `false`, regardless
+          # of the value entered here.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # required for Code scanning alerts
+      - name: "Upload SARIF results to code scanning"
+        uses: github/codeql-action/upload-sarif@83f0fe6c4988d98a455712a27f0255212bba9bd4 # v2.3.6
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -5,15 +5,12 @@ image analysis.
 including Windows, Linux and macOS.
 
 Build instructions for all platforms are available on the Slicer wiki:
-
-                      https://slicer.readthedocs.io/en/latest/developer_guide/build_instructions/index.html
+- https://slicer.readthedocs.io/en/latest/developer_guide/build_instructions/index.html
 
 For Slicer community announcements and support, visit:
-
-                      https://discourse.slicer.org
+- https://discourse.slicer.org
 
 For documentation, tutorials, and more information, please see:
-
-                      https://www.slicer.org
+- https://www.slicer.org
 
 See License.txt for information on using and contributing.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Slicer/Slicer/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Slicer/Slicer)
+
 Slicer, or 3D Slicer, is a free, open source software package for visualization and
 image analysis.
 


### PR DESCRIPTION
This adds the OSSF scorecard action (https://github.com/ossf/scorecard-action) to display open-source health. 

Some security engineering groups have requested that open-source repositories should display their OSSF score. Adding this GitHub action will help fulfill their request that using 3D Slicer is safe.